### PR TITLE
Fix: use serverless 3xx lifecycle events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,8 @@ class Plugin {
         this.sumoFnName = 'sumologic-shipping-function'
 
         this.hooks = {
-            'before:deploy:createDeploymentArtifacts': this.beforeDeployCreateDeploymentArtifacts.bind(this),
-            'deploy:compileEvents': this.deployCompileEvents.bind(this),
+            'before:package:createDeploymentArtifacts': this.beforeDeployCreateDeploymentArtifacts.bind(this),
+            'package:compileEvents': this.deployCompileEvents.bind(this),
             'after:deploy:deploy': this.afterDeployDeploy.bind(this)
         };
     }


### PR DESCRIPTION
Serverless 3xx has a newly introduced package stage and new lifecycle events.

`before:package:createDeploymentArtifacts` - before zipping
`package:compileEvents` - before the cloudformation template is generated

earlier these were handled just before deploy

These hooks were not being executed before and the shipping function was not part of the package or resulting cloud-formation template as a result